### PR TITLE
Cleanup common latin characters

### DIFF
--- a/src/stableString.ts
+++ b/src/stableString.ts
@@ -1,3 +1,7 @@
 export const getStableString = (str: string) => {
-  return str.toLocaleLowerCase().split(' ').join('_');
+  return str.toLocaleLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, "")
+    .split(' ')
+    .join('_');
 };


### PR DESCRIPTION
`crème brulée` would previously return `crème_brulée`.
It will now return `creme_brulee`.

Taken from: https://stackoverflow.com/a/49901740/4625581