### PR TITLE
feature: ignore files by regex

### DIFF
--- a/src/__test__/filterFiles.test.ts
+++ b/src/__test__/filterFiles.test.ts
@@ -1,0 +1,36 @@
+import { filterFiles, DEFAULT_TEST_FILE_REGEX } from "../filterFiles";
+
+const mockFilesPath = [
+  "src/__test__/filterFiles.test.ts",
+  "src/__test__/generateResources.spec.ts",
+  "src/__testfixtures__/CallExpression.input.tsx",
+  "src/__testfixtures__/CallExpression.output.tsx",
+  "src/userArgv.js",
+  "src/visitorChecks.ts",
+  "src/run.ex",
+];
+
+const shellFindMock = () => mockFilesPath;
+const filterFilesWithShell = filterFiles(shellFindMock);
+
+describe("filterFiles", () => {
+  it(`should receive a path and return a list of files with (js|ts|tsx) extension and ignore files that match with ${DEFAULT_TEST_FILE_REGEX}`, () => {
+    const files = filterFilesWithShell("./src");
+
+    expect(files).toStrictEqual([
+      "src/__testfixtures__/CallExpression.input.tsx",
+      "src/__testfixtures__/CallExpression.output.tsx",
+      "src/userArgv.js",
+      "src/visitorChecks.ts",
+    ]);
+  });
+
+  it("should receive a path, a custom regex and return a list of files with (js|ts|tsx) extension and ignore the files that match with regex", () => {
+    const files = filterFilesWithShell("./src", "/(__testfixtures__|__test__)/");
+
+    expect(files).toStrictEqual([
+      "src/userArgv.js",
+      "src/visitorChecks.ts",
+    ]);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,10 @@ import { generateResources } from './generateResources';
 type Argv = {
   src: string,
   keyMaxLength: number,
+  ignoreFilesRegex: string;
 }
+
+const DEFAULT_TEST_FILE_REGEX = '(/__tests__/.*|(\\.|/)(test|spec))\\.(js|ts|tsx|jsx)?$';
 
 export const run = (argv: Argv) => {
   argv = yargs(argv || process.argv.slice(2))
@@ -23,9 +26,15 @@ export const run = (argv: Argv) => {
       'src',
       'The source to collect strings'
     )
+    .default('ignoreFilesRegex', DEFAULT_TEST_FILE_REGEX)
+    .describe(
+      'ignoreFilesRegex',
+      `The regex to ignore files in the source.\nThe files with this match is ignored by default:\n${DEFAULT_TEST_FILE_REGEX}`
+    )
     .argv;
-
-  const jsFiles = shell.find(argv.src).filter(path => /\.(js|ts|tsx)$/.test(path));
+  
+  const ignoreFilesRegex = new RegExp(argv.ignoreFilesRegex);
+  const jsFiles = shell.find(argv.src).filter(path => /\.(js|ts|tsx)$/.test(path) && !ignoreFilesRegex.test(path));
 
   generateResources(jsFiles, argv.keyMaxLength);
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,14 +2,13 @@ import yargs from 'yargs';
 import shell from 'shelljs';
 
 import { generateResources } from './generateResources';
+import { filterFiles, DEFAULT_TEST_FILE_REGEX } from './filterFiles';
 
 type Argv = {
   src: string,
   keyMaxLength: number,
   ignoreFilesRegex: string;
 }
-
-const DEFAULT_TEST_FILE_REGEX = '(/__tests__/.*|(\\.|/)(test|spec))\\.(js|ts|tsx|jsx)?$';
 
 export const run = (argv: Argv) => {
   argv = yargs(argv || process.argv.slice(2))
@@ -33,8 +32,7 @@ export const run = (argv: Argv) => {
     )
     .argv;
   
-  const ignoreFilesRegex = new RegExp(argv.ignoreFilesRegex);
-  const jsFiles = shell.find(argv.src).filter(path => /\.(js|ts|tsx)$/.test(path) && !ignoreFilesRegex.test(path));
+  const jsFiles = filterFiles(shell.find)(argv.src, argv.ignoreFilesRegex);
 
   generateResources(jsFiles, argv.keyMaxLength);
 };

--- a/src/filterFiles.ts
+++ b/src/filterFiles.ts
@@ -1,0 +1,14 @@
+export const DEFAULT_TEST_FILE_REGEX =
+  "(/__tests__/.*|(\\.|/)(test|spec))\\.(js|ts|tsx|jsx)?$";
+
+type ShellFind = (...path: Array<string | string[]>) => string[];
+
+export const filterFiles = (shellFind: ShellFind) => (
+  path: string,
+  ignoreFilesRegex?: string
+) => {
+  const regex = new RegExp(ignoreFilesRegex || DEFAULT_TEST_FILE_REGEX);
+  return shellFind(path).filter(
+    (path) => /\.(js|ts|tsx)$/.test(path) && !regex.test(path)
+  );
+};


### PR DESCRIPTION
Hello everyone,

This pull request implement a feature that possible users specify which files must be ignored.
 
This work is related to this issue #56 where the idea is just ignore the test files, but I think we could be more generic and ignore any files by a regex (by default the test files is ignored).

